### PR TITLE
Update api to work with current acme.sh and current awscli

### DIFF
--- a/dns-route53-python.sh
+++ b/dns-route53-python.sh
@@ -8,7 +8,7 @@ if [ -z "$AWS" ]; then
 fi
 
 #Usage: add _acme-challenge.www.domain.com "XKrx...."
-dns-route53-python-add() {
+dns_route53_add() {
   if [ -z "$AWS" ]; then
     _err "AWS not found. Please install globally using PIP or update AWS variable in $CONF"
     return 1
@@ -53,6 +53,7 @@ dns-route53-python-add() {
   _debug "----JSON----"
   [ ! -z "$DEBUG" ] && cat $JSONFILE
   _debug "----JSON----"
+  _debug "$AWS --output text $PROFILE route53 change-resource-record-sets --hosted-zone-id $_domain_id --change-batch file://$JSONFILE"
   RESULT=`$AWS --output text $PROFILE route53 change-resource-record-sets --hosted-zone-id $_domain_id --change-batch file://$JSONFILE 2>$ERRFILE | grep "CHANGEINFO"`
   _debug RESULT "$RESULT"
   rm -f $JSONFILE
@@ -75,7 +76,7 @@ dns-route53-python-add() {
     for run in {1..3}
     do
       sleep 15
-      _check-changeid $CHANGE_ID
+      _check_changeid $CHANGE_ID
       _info "State of change request is $RESULT_STATUS_CODE."
       [ "$RESULT_STATUS_CODE" == "INSYNC" ] && break;
     done
@@ -113,7 +114,7 @@ _find_root() {
     fi
 
     if _test_domain $h; then
-      if [ ! -z $_domain_id ]; then
+      if [ ! -z "$_domain_id" ]; then
         _sub_domain=$(printf $domain | cut -d . -f 1-$p)
         _domain=$h
         return 0
@@ -130,14 +131,15 @@ _test_domain() {
   local basedomain=$1
   local errfile=$(mktemp)
   _info "Searching for ZoneID for $basedomain"
-  _domain_id=`$AWS --output text $PROFILE route53 list-hosted-zones-by-name --dns-name $basedomain 2>$errfile | grep "HOSTEDZONES" | awk '{ print $3; }' | sed -r 's/\/hostedzone\/([A-Z0-9]+)/\1/'`
+  _domain_id=`$AWS --output text $PROFILE route53 list-hosted-zones-by-name --dns-name $basedomain --max-items 1 2>$errfile | grep "HOSTEDZONES" | awk '{ print $3; }' | sed -r 's/\/hostedzone\/([A-Z0-9]+)/\1/'`
   _debug _domain_id $_domain_id
+  declare -p _domain_id
   local errorcount=`wc -l < $errfile`
   return $errorcount
 }
 
 #Usage: _check-changeid /change/C30DVTKZ000000
-_check-changeid() {
+_check_changeid() {
   # aws --output text route53 get-change --id /change/C30DVTKZ000000
   RESULT=`$AWS --output text $PROFILE route53 get-change --id $1`
   _debug RESULT "$RESULT"

--- a/dns-route53-python.sh
+++ b/dns-route53-python.sh
@@ -133,7 +133,6 @@ _test_domain() {
   _info "Searching for ZoneID for $basedomain"
   _domain_id=`$AWS --output text $PROFILE route53 list-hosted-zones-by-name --dns-name $basedomain --max-items 1 2>$errfile | grep "HOSTEDZONES" | awk '{ print $3; }' | sed -r 's/\/hostedzone\/([A-Z0-9]+)/\1/'`
   _debug _domain_id $_domain_id
-  declare -p _domain_id
   local errorcount=`wc -l < $errfile`
   return $errorcount
 }


### PR DESCRIPTION
As above, bitrot has happened over time, both in awscli output (or maybe this was just never tested in an account with multiple route53 hosted zones?), and in acme.sh's api.
